### PR TITLE
Fix bug: unknown namespace

### DIFF
--- a/rss-synd.tcl
+++ b/rss-synd.tcl
@@ -28,6 +28,7 @@
 if {[catch {source scripts/rss-synd-settings.tcl} err]} {
   putlog "Error: Could not load 'rss-synd-settings.tcl file.'";
 }
+namespace eval ::rss-synd { }
 
 proc ::rss-synd::init {args} {
 	variable rss


### PR DESCRIPTION
```
can't create procedure "::rss-synd::init": unknown namespace
    while executing
"proc ::rss-synd::init {args} {
        variable rss
        variable default
        variable version
        variable packages

        set version(number)     0.5.1
        set version(date)       "20..."
    (file "scripts/thirds/rss-synd.tcl" line 32)
    invoked from within
```